### PR TITLE
fix(back): substituir baseUrl deprecado por paths no tsconfig

### DIFF
--- a/back/tsconfig.json
+++ b/back/tsconfig.json
@@ -9,7 +9,9 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "paths": {
+      "src/*": ["./src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Problema

O gate novo proposto no #334 expôs um erro real que já está na `main`: o TypeScript 6 (`typescript@6.0.3`, resolvido pelo lockfile) trata `baseUrl` no `tsconfig.json` como **erro de deprecação (TS5101)**, quebrando `nest build` e o build da imagem Docker (deploy de produção incluso). Localmente o erro não aparecia com `node_modules` desatualizado (TS 5.x).

## Solução

Substitui `baseUrl` pelo mapeamento `paths` (`src/* -> ./src/*`), que é o caminho de migração oficial do TS 6 e não depende de `baseUrl` desde o TS 4.1:

- Mantém os 147 imports não-relativos `from 'src/...'` usados em `src/` e `test/` type-checando normalmente (ts-jest usa o `tsconfig.json`; o runtime dos testes já era resolvido pelo `moduleNameMapper` do Jest).
- O Nest CLI continua reescrevendo os aliases para caminhos relativos no JS emitido em `dist/` — **sem impacto no runtime de produção** (verificado no `dist`).

## Verificação (com `node_modules` sincronizado ao lockfile: TS 6.0.3, Prisma 7.8.0)

- ✅ `npm run lint`
- ✅ `npm test` — 170/170 (com `DATABASE_URL` definida, como no CI)
- ✅ `npm run build` — falhava com TS5101 antes do fix
- ✅ `docker build ./back` — mesmo cenário do check que falhou no #334

## Cobertura

A proteção permanente deste cenário são os passos **Build do backend** e **Build da imagem Docker** do gate de PR propostos no #334, que falham sem este fix e passam com ele.