### PR TITLE
test(back): cobrir validação de DATABASE_URL no PrismaService

### DIFF
--- a/back/test/database/prisma.service.spec.ts
+++ b/back/test/database/prisma.service.spec.ts
@@ -16,6 +16,22 @@ describe('PrismaService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('constructor', () => {
+    const originalDatabaseUrl = process.env.DATABASE_URL;
+
+    afterEach(() => {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+    });
+
+    it('should throw when DATABASE_URL is not set', () => {
+      delete process.env.DATABASE_URL;
+
+      expect(() => new PrismaService()).toThrow(
+        'DATABASE_URL environment variable is not set',
+      );
+    });
+  });
+
   describe('onModuleInit', () => {
     it('should call $connect on initialization', async () => {
       jest.spyOn(service, '$connect').mockResolvedValue();


### PR DESCRIPTION
## Contexto

A correção 7647354 (`fix(back): validar DATABASE_URL na construção do PrismaService`) entrou na `main` sem teste cobrindo o cenário de `DATABASE_URL` ausente — o spec existente só cobria a construção com a variável definida e o `onModuleInit`.

## Mudança

Adiciona caso no `prisma.service.spec.ts` garantindo que a construção do `PrismaService` sem `DATABASE_URL` lança o erro esperado (mensagem exata do guard — sem a correção, o erro seria outro, vindo do `PrismaPg`). A variável de ambiente é restaurada após cada caso para não vazar estado entre testes.

## Verificação

- ✅ `npm test -- test/database/prisma.service.spec.ts` — 3/3 passando