### PR TITLE
ci(back): corrigir pipeline pós-merge (testes, push ao GHCR e injeção)

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -25,6 +25,10 @@ jobs:
   prepare-tag:
     name: 1. Preparar nova tag
     runs-on: ubuntu-latest
+    # PR fechada sem merge também dispara o evento 'closed' — sem esta
+    # condição o pipeline publicaria/deployaria código não mesclado.
+    # Os demais jobs dependem deste (needs) e são pulados junto.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     outputs:
       new_tag: ${{ steps.nova_tag.outputs.nova_tag }}
       tipo:    ${{ steps.tipo.outputs.tipo }}

--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -7,7 +7,13 @@ on:
     paths:
       - 'back/**'
   workflow_dispatch:
-  
+
+# O GITHUB_TOKEN precisa de escrita para publicar a imagem no GHCR,
+# criar a release e atualizar o badge de cobertura no README.
+permissions:
+  contents: write
+  packages: write
+
 env:
   IMAGE_NAME: back-${{ github.event.repository.name }}
   REGISTRY: ghcr.io
@@ -29,10 +35,14 @@ jobs:
       - name: Instalar GitHub CLI
         run: sudo apt-get install -y gh
 
+      # O corpo da PR entra via env para não ser interpolado no shell
+      # (corpos com aspas/crases — ex.: dependabot — quebravam o passo).
       - name: Extrair tipo de mudança da PR
         id: tipo
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          echo "${{ github.event.pull_request.body }}" > body.txt
+          printf '%s\n' "$PR_BODY" > body.txt
       
           tipo=""
           if grep -q "\[x\] marco-no-projeto" body.txt; then
@@ -77,19 +87,31 @@ jobs:
     name: 2. Rodar testes do backend
     runs-on: ubuntu-latest
     needs: prepare-tag
-  
+
+    # Os testes unitários mockam o Prisma, mas o PrismaService valida a
+    # presença de DATABASE_URL na construção — o valor não precisa apontar
+    # para um banco real (mesmo padrão do pr-checks.yml).
+    env:
+      DATABASE_URL: postgresql://test:test@localhost:5432/testdb
+
     steps:
       - uses: actions/checkout@v4
-  
+
       - name: Configurar Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-  
+
       - name: Instalar dependências
         working-directory: ./back
         run: npm ci
-  
+
+      # Prisma v7 removeu o postinstall automático: sem gerar o client,
+      # o type-check dos testes falha (PrismaService sem os models).
+      - name: Gerar cliente Prisma
+        working-directory: ./back
+        run: npx prisma generate
+
       - name: Rodar testes com cobertura
         working-directory: ./back
         run: npx jest --coverage --coverageReporters=json-summary
@@ -111,14 +133,13 @@ jobs:
           echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
 
       - name: Atualizar badge no README
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Atualizar badge no README.md
           BADGE="![Coverage](https://img.shields.io/badge/Coverage-${{ steps.coverage.outputs.coverage }}%25-brightgreen)"
           sed -i '0,/<!-- COVERAGE_BADGE -->/s|.*<!-- COVERAGE_BADGE -->|'"$BADGE"' <!-- COVERAGE_BADGE -->|' README.md
-        
-          # Configurar autenticação com GitHub CLI
-          echo "${{ secrets.GHCR_PAT }}" | gh auth login --with-token
-        
+
           # Fazer commit e push via GitHub API
           gh api \
             --method PUT \
@@ -188,8 +209,10 @@ jobs:
           docker tag ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.TAG }} ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
 
       # Push Docker image
+      # GITHUB_TOKEN com permissions.packages: write substitui o PAT
+      # (GHCR_PAT), que vinha falhando com permission_denied no push.
       - name: Login no GHCR
-        run: echo "${{ secrets.GHCR_PAT }}" | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
 
       - name: Push Docker image
         run: |
@@ -219,7 +242,7 @@ jobs:
             Release gerada automaticamente a partir da Pull Request #${{ github.event.pull_request.number }}
             Tipo de mudança: ${{ env.TIPO }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GHCR_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 # --------------------------------------------------------------------
 # 6) DEPLOY APP --------------------------------------------------


### PR DESCRIPTION
## Contexto

O `backend-pipeline` (pós-merge) **falha em 100% das execuções desde 11/11/2025** (~8 meses). Nenhuma imagem foi publicada nem deploy disparado nesse período. São três causas independentes:

## Correções

### 1. Job de testes: faltavam `prisma generate` e `DATABASE_URL`
33 das 36 suites falhavam com `TS2339: Property 'anamnesis' does not exist on type 'PrismaService'` (client Prisma não gerado — o v7 removeu o postinstall automático) e o `PrismaService` valida `DATABASE_URL` na construção. Alinhado ao que o `pr-checks.yml` já faz.

### 2. Push ao GHCR / release / badge: `GHCR_PAT` com `permission_denied`
O push falhava com `denied: permission_denied: create_package` — o PAT está sem permissão (ou expirado). Trocado pelo `GITHUB_TOKEN` com `permissions: contents/packages: write`, o mecanismo padrão que não depende de PAT de pessoa.

### 3. Injeção do corpo da PR no shell
`echo "${{ github.event.pull_request.body }}"` interpolava o corpo direto no script — quebra com aspas/crases (todo PR do dependabot) e é vetor de injeção de comando. Movido para variável de ambiente com `printf`.

## Verificação

- ✅ YAML validado.
- ✅ Comando exato do job de testes reproduzido localmente com as novas condições: `npx jest --coverage --coverageReporters=json-summary` → 36/36 suites, `coverage-summary.json` gerado (96.38%).
- ⚠️ O restante (push GHCR, release, badge) só é verificável em execução real, pois o evento é `pull_request: closed`. **Este PR não dispara o pipeline ao ser mesclado** (o filtro de paths é `back/**`); a validação definitiva será no próximo merge que tocar `back/`.

## Atenção (decisão de equipe)

1. Se o pacote `back-edutrace` no GHCR não estiver vinculado a este repositório com acesso de escrita para o Actions, o push pode continuar negado — nesse caso é ajuste nas configurações do pacote (admin).
2. Com o pipeline funcionando de novo, **o próximo merge em `back/` vai publicar imagem e disparar o webhook do Portainer — colocando em produção 8 meses de mudanças acumuladas de uma vez**. Recomendo a equipe validar o ambiente antes desse primeiro deploy.