### PR TITLE
fix(front): corrigir e-mail de contato no Termo de Consentimento

### DIFF
--- a/front/src/components/TermoConsentimento.tsx
+++ b/front/src/components/TermoConsentimento.tsx
@@ -26,7 +26,7 @@ export default function TermoConsentimento() {
         </p>
         <p>
           <span className="font-semibold">Contato da Pesquisadora:</span>{" "}
-          sayane.marlla@belojardim.ifpe.edu.be, (81) 97306-3357
+          sayane.marlla@belojardim.ifpe.edu.br, (81) 97306-3357
         </p>
       </div>
 


### PR DESCRIPTION
O domínio do e-mail da pesquisadora estava com o TLD errado (.edu.be em vez de .edu.br).

## 📌 Tipo de mudançaAdd commentMore actions

<!-- Selecione UMA das opções abaixo -->

(Selecione apenas uma opçaõ)
tipo:

- [ ] marco-no-projeto
- [ ] nova-feature
- [x] bug-fix

## ✅ Checklist

<!-- Marque com um "x" os itens que se aplicam -->

checklist:

- [x] O código foi testado localmente
- [ ] Foram adicionados testes relevantes
- [x] Não quebrou nenhuma funcionalidade existente
- [ ] A documentação foi atualizada

---

> _Preencha todos os campos de forma clara. Este template é lido automaticamente por nossa pipeline._
