### PR TITLE
fix(front): liberar acesso sem login à rota /forgot-password no middl…

### DIFF
--- a/front/src/middleware.ts
+++ b/front/src/middleware.ts
@@ -9,8 +9,9 @@ export function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
   const isLoginPage = pathname === '/'
+  const isPublicPage = isLoginPage || pathname === '/forgot-password'
 
-  if (!token && !isLoginPage) {
+  if (!token && !isPublicPage) {
     return NextResponse.redirect(new URL('/', request.url))
   }
 


### PR DESCRIPTION
…eware

O middleware redirecionava para o login qualquer rota sem o cookie de token, exceto a raiz. A página /forgot-password precisa ser pública, senão o usuário deslogado (justamente quem esqueceu a senha) nunca a alcança. Rotas privadas seguem protegidas.

## 📌 Tipo de mudançaAdd commentMore actions

<!-- Selecione UMA das opções abaixo -->

(Selecione apenas uma opçaõ)
tipo:

- [ ] marco-no-projeto
- [ ] nova-feature
- [x] bug-fix

## ✅ Checklist

<!-- Marque com um "x" os itens que se aplicam -->

checklist:

- [x] O código foi testado localmente
- [ ] Foram adicionados testes relevantes
- [x] Não quebrou nenhuma funcionalidade existente
- [ ] A documentação foi atualizada

---

> _Preencha todos os campos de forma clara. Este template é lido automaticamente por nossa pipeline._
