### PR TITLE
fix(front): remover regex numérico do campo de senha do login

### DIFF
--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -112,7 +112,6 @@ function LoginPage() {
               label="Senha"
               type={showPassword ? "text" : "password"}
               required
-              pattern="[0-9]{8,11}"
               icon
               button
               class="w-full"


### PR DESCRIPTION
## 📌 Tipo de mudança
tipo:
- [x] bug-fix

## Descrição
Remove `pattern="[0-9]{8,11}"` do input de senha do login, que bloqueava o submit de
qualquer senha alfanumérica válida.

Closes #380

## ✅ Checklist
checklist:
- [x] O código foi testado localmente
- [ ] Foram adicionados testes relevantes
- [x] Não quebrou nenhuma funcionalidade existente
- [ ] A documentação foi atualizada