### PR TITLE
security(back+front): exigir senha com no mínimo 8 caracteres

### DIFF
--- a/back/src/auth/dto/reset-password.dto.ts
+++ b/back/src/auth/dto/reset-password.dto.ts
@@ -4,12 +4,12 @@ import { VerifyResetCodeDto } from './verify-reset-code.dto';
 
 export class ResetPasswordDto extends VerifyResetCodeDto {
   @ApiProperty({
-    description: 'Nova senha do usuário com no mínimo 6 caracteres.',
+    description: 'Nova senha do usuário com no mínimo 8 caracteres.',
     example: 'senhaSegura123',
-    minLength: 6,
+    minLength: 8,
   })
   @IsNotEmpty({ message: 'O campo password não deve estar vazio.' })
   @IsString({ message: 'O campo password deve ser uma string' })
-  @MinLength(6, { message: 'A senha deve ter no minímo 6 caracteres' })
+  @MinLength(8, { message: 'A senha deve ter no mínimo 8 caracteres' })
   password: string;
 }

--- a/back/src/users/dto/create-user.dto.ts
+++ b/back/src/users/dto/create-user.dto.ts
@@ -39,13 +39,13 @@ export class CreateUserDto {
   email: string;
 
   @ApiProperty({
-    description: 'Senha do usuário com no mínimo 6 caracteres.',
+    description: 'Senha do usuário com no mínimo 8 caracteres.',
     example: 'senhaSegura123',
-    minLength: 6,
+    minLength: 8,
   })
   @IsNotEmpty({ message: 'O campo password não deve estar vazio.' })
   @IsString({ message: 'O campo password deve ser uma string' })
-  @MinLength(6, { message: 'A senha deve ter no minímo 6 caracteres' })
+  @MinLength(8, { message: 'A senha deve ter no mínimo 8 caracteres' })
   password: string;
 
   @ApiProperty({

--- a/front/src/app/forgot-password/page.tsx
+++ b/front/src/app/forgot-password/page.tsx
@@ -130,11 +130,11 @@ function ForgotPasswordPage() {
   const handleResetPassword = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (password.length < 6) {
+    if (password.length < 8) {
       Swal.fire({
         icon: "error",
         title: "Senha inválida",
-        text: "A senha deve ter no mínimo 6 caracteres.",
+        text: "A senha deve ter no mínimo 8 caracteres.",
         confirmButtonColor: "#047857",
         confirmButtonText: "Entendi",
       });
@@ -296,7 +296,7 @@ function ForgotPasswordPage() {
                 label="Nova senha"
                 type={showPassword ? "text" : "password"}
                 required
-                minlength={6}
+                minlength={8}
                 icon
                 button
                 class="w-full"
@@ -335,7 +335,7 @@ function ForgotPasswordPage() {
                 label="Confirmar senha"
                 type={showConfirmPassword ? "text" : "password"}
                 required
-                minlength={6}
+                minlength={8}
                 icon
                 button
                 class="w-full"


### PR DESCRIPTION
## 📌 Tipo de mudança
tipo:
- [x] bug-fix

## Descrição
Aumenta o mínimo de senha de 6 para 8 caracteres no cadastro (`create-user.dto.ts`) e
na redefinição de senha (`reset-password.dto.ts` + tela `forgot-password`). O login
(`auth.dto.ts`) continua em 6 de propósito, pra não travar usuários já cadastrados.

Closes #382

## ✅ Checklist
checklist:
- [x] O código foi testado localmente
- [ ] Foram adicionados testes relevantes
- [x] Não quebrou nenhuma funcionalidade existente
- [ ] A documentação foi atualizada