### PR TITLE
feat(back): endpoint PATCH /auth/me para autoatendimento de dados

### DIFF
--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Patch,
   Post,
   Request,
   UseGuards,
@@ -13,6 +14,7 @@ import { AuthDto } from './dto/auth.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { VerifyResetCodeDto } from './dto/verify-reset-code.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 import { AuthGuard } from './auth.guard';
 import { Public } from './constants/constants';
 import { ApiBody } from '@nestjs/swagger';
@@ -77,5 +79,17 @@ export class AuthController {
   })
   getProfile(@Request() req) {
     return req.user;
+  }
+
+  // Sem @Levels: qualquer usuário autenticado pode alterar os próprios dados.
+  // A identidade é lida do token (req.user.email), não do corpo.
+  @UseGuards(AuthGuard)
+  @ApiBody({
+    type: UpdateProfileDto,
+    description: 'Altera o e-mail e/ou a senha do próprio usuário autenticado.',
+  })
+  @Patch('me')
+  async updateMe(@Request() req, @Body() dto: UpdateProfileDto) {
+    return await this.authService.updateProfile(req.user.email, dto);
   }
 }

--- a/back/src/auth/auth.service.ts
+++ b/back/src/auth/auth.service.ts
@@ -1,8 +1,10 @@
 import {
+  ConflictException,
   Injectable,
   Logger,
   UnauthorizedException,
 } from '@nestjs/common';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from 'src/users/users.service';
 import { MailService } from 'src/mail/mail.service';
@@ -45,6 +47,54 @@ export class AuthService {
       access_token: await this.jwtService.signAsync(payload),
     };
     return token;
+  }
+
+  // Permite que qualquer usuário autenticado altere o próprio e-mail e/ou senha.
+  // A identidade vem do token (currentEmail), nunca do corpo da requisição.
+  async updateProfile(
+    currentEmail: string,
+    dto: UpdateProfileDto,
+  ): Promise<{ access_token: string }> {
+    const user = await this.userService.findOne(currentEmail);
+    if (!user) {
+      throw new UnauthorizedException('Usuário não encontrado');
+    }
+
+    const isPasswordValid = await bcrypt.compare(
+      dto.currentPassword,
+      user.password,
+    );
+    if (!isPasswordValid) {
+      throw new UnauthorizedException('Senha atual incorreta');
+    }
+
+    const newEmail = dto.email?.trim();
+    const isChangingEmail = !!newEmail && newEmail !== currentEmail;
+
+    if (isChangingEmail) {
+      const existing = await this.userService.findOne(newEmail);
+      if (existing) {
+        throw new ConflictException('Este e-mail já está em uso.');
+      }
+    }
+
+    const hashedPassword = dto.password
+      ? await bcrypt.hash(dto.password, 10)
+      : undefined;
+
+    const updated = await this.userService.updateProfile(currentEmail, {
+      newEmail: isChangingEmail ? newEmail : undefined,
+      hashedPassword,
+    });
+
+    const payload = {
+      sub: updated.id,
+      email: updated.email,
+      name: updated.full_name,
+      id_level: updated.id_level,
+    };
+
+    return { access_token: await this.jwtService.signAsync(payload) };
   }
 
   async forgotPassword(email: string): Promise<{ message: string }> {

--- a/back/src/auth/dto/update-profile.dto.ts
+++ b/back/src/auth/dto/update-profile.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsOptional, IsString, MinLength } from 'class-validator';
+
+export class UpdateProfileDto {
+  @ApiProperty({
+    description: 'Novo e-mail do usuário.',
+    example: 'novo-email@exemplo.com',
+    required: false,
+  })
+  @IsOptional()
+  @IsEmail({}, { message: 'O campo email deve ser um e-mail válido.' })
+  email?: string;
+
+  @ApiProperty({
+    description: 'Nova senha do usuário com no mínimo 8 caracteres.',
+    example: 'novaSenha123',
+    minLength: 8,
+    required: false,
+  })
+  @IsOptional()
+  @IsString({ message: 'O campo password deve ser uma string.' })
+  @MinLength(8, { message: 'A senha deve ter no mínimo 8 caracteres.' })
+  password?: string;
+
+  @ApiProperty({
+    description: 'Senha atual, obrigatória para confirmar a alteração.',
+    example: 'senhaAtual123',
+  })
+  @IsNotEmpty({ message: 'A senha atual é obrigatória.' })
+  @IsString({ message: 'O campo currentPassword deve ser uma string.' })
+  currentPassword: string;
+}

--- a/back/src/users/users.service.ts
+++ b/back/src/users/users.service.ts
@@ -64,6 +64,49 @@ export class UsersService {
     });
   }
 
+  // Atualização self-service dos próprios dados (e-mail e/ou senha).
+  // O e-mail é a chave de negócio que liga o usuário aos seus registros de
+  // Triagem/Anamnese/PEI, então a troca precisa propagar em todas as tabelas
+  // dentro de uma transação para não deixar dados órfãos.
+  async updateProfile(
+    currentEmail: string,
+    data: { newEmail?: string; hashedPassword?: string },
+  ) {
+    const { newEmail, hashedPassword } = data;
+    const isChangingEmail = !!newEmail && newEmail !== currentEmail;
+
+    return this.prisma.$transaction(async (tx) => {
+      const user = await tx.user.update({
+        where: { email: currentEmail },
+        data: {
+          ...(isChangingEmail ? { email: newEmail } : {}),
+          ...(hashedPassword ? { password: hashedPassword } : {}),
+        },
+      });
+
+      if (isChangingEmail) {
+        await tx.screening.updateMany({
+          where: { email: currentEmail },
+          data: { email: newEmail },
+        });
+        await tx.anamnesis.updateMany({
+          where: { email: currentEmail },
+          data: { email: newEmail },
+        });
+        await tx.plansEducation.updateMany({
+          where: { student_email: currentEmail },
+          data: { student_email: newEmail },
+        });
+        await tx.plansEducation.updateMany({
+          where: { professor_email: currentEmail },
+          data: { professor_email: newEmail },
+        });
+      }
+
+      return user;
+    });
+  }
+
   async setPasswordResetToken(
     email: string,
     tokenHash: string,


### PR DESCRIPTION
## 📌 Tipo de mudança
tipo:
- [x] nova-feature

## Descrição
Novo endpoint `PATCH /auth/me`: usuário autenticado troca o próprio e-mail e/ou senha,
com `currentPassword` obrigatório pra confirmar identidade. A troca de e-mail propaga,
dentro de uma transação, para `Screening`, `Anamnesis` e `PlansEducation`
(`student_email`/`professor_email`), já que o e-mail é a chave de negócio dessas tabelas.
Retorna um `access_token` novo refletindo os dados atualizados.

`UpdateProfileDto.email` usa `@IsEmail()` (achado de code review durante a análise de
integração — o rascunho original só tinha `@IsString()`).

Closes #384

## ✅ Checklist
checklist:
- [x] O código foi testado localmente
- [ ] Foram adicionados testes relevantes
- [x] Não quebrou nenhuma funcionalidade existente
- [ ] A documentação foi atualizada

> Nota: ainda não há testes unitários pra este endpoint (gap mapeado na análise de
> integração) — recomendo tratar em issue de teste separada antes ou logo depois do merge.