### PR TITLE
fix(front): impedir prototype pollution nos handlers de formulário aninhado

### DIFF
--- a/front/src/app/editar-anamnese/page.tsx
+++ b/front/src/app/editar-anamnese/page.tsx
@@ -92,7 +92,8 @@ function AnamnesePage() {
 
   const handleInputChange = (name: string, value: string) => {
     const keys = name.split('.');
-    
+    if (keys.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) return;
+
     setFormData(prevData => {
       const newData = JSON.parse(JSON.stringify(prevData));
       let current = newData;
@@ -106,7 +107,8 @@ function AnamnesePage() {
 
   const handleCheckboxClick = (name: string) => {
     const keys = name.split('.');
-    
+    if (keys.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) return;
+
     setFormData(prevData => {
       // Criar uma cópia profunda para segurança
       const newData = JSON.parse(JSON.stringify(prevData));

--- a/front/src/app/editar-pei/page.tsx
+++ b/front/src/app/editar-pei/page.tsx
@@ -99,6 +99,7 @@ function PEIPage() {
 
   const handleInputChange = (name: string, value: string) => {
     const keys = name.split('.');
+    if (keys.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) return;
     setFormData(prevData => {
       const newData = JSON.parse(JSON.stringify(prevData));
       let current = newData;
@@ -112,6 +113,7 @@ function PEIPage() {
 
   const handleCheckboxClick = (name: string) => {
     const keys = name.split('.');
+    if (keys.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) return;
     setFormData(prevData => {
       const newData = JSON.parse(JSON.stringify(prevData));
       let current = newData;

--- a/front/src/app/editar-triagem/page.tsx
+++ b/front/src/app/editar-triagem/page.tsx
@@ -120,6 +120,8 @@ function TriagemPage() {
   // Manipulador para inputs de texto (BrInput)
   const handleInputChange = (name: string, value: string) => {
     const keys = name.split('.');
+    // Rejeita chaves que permitiriam poluir o protótipo do objeto
+    if (keys.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) return;
     setFormData(prevData => {
       const newData = JSON.parse(JSON.stringify(prevData));
       let current = newData;
@@ -134,6 +136,8 @@ function TriagemPage() {
   // Manipulador para o CLIQUE no checkbox que inverte o valor no estado
   const handleCheckboxClick = (name: string) => {
     const keys = name.split('.');
+    // Rejeita chaves que permitiriam poluir o protótipo do objeto
+    if (keys.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) return;
     setFormData(prevData => {
       const newData = JSON.parse(JSON.stringify(prevData));
       let current = newData;


### PR DESCRIPTION
## Resumo

Fecha os 3 alertas do CodeQL (`js/prototype-pollution-utility`, severidade medium) nas páginas de edição:

- `front/src/app/editar-anamnese/page.tsx`
- `front/src/app/editar-pei/page.tsx`
- `front/src/app/editar-triagem/page.tsx`

As três páginas repetem o mesmo padrão: `handleInputChange`/`handleCheckboxClick` fazem `name.split('.')` e caminham pelo objeto de estado atribuindo no último nível, sem validar as chaves — um caminho contendo `__proto__`, `constructor` ou `prototype` poderia poluir o protótipo. Hoje o `name` vem de atributos de campos definidos no próprio código (exploitabilidade baixa), mas a guarda elimina a classe de problema e é o padrão de sanitização reconhecido pelo CodeQL.

A correção adiciona no início dos dois handlers de cada página:

```ts
if (keys.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) return;
```

Os alertas devem fechar automaticamente na próxima varredura do CodeQL na `main`.

## Verificação

- `npm run lint`: OK
- `npm run build` (next build): OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)