### PR TITLE
fix(back): mascarar CPF nos retornos da API de usuários e estudantes

### DIFF
--- a/back/src/common/mask-cpf.ts
+++ b/back/src/common/mask-cpf.ts
@@ -1,0 +1,21 @@
+const FULLY_MASKED_CPF = '***';
+
+export function maskCpf(cpf: string): string {
+  const digits = (cpf ?? '').replace(/\D/g, '');
+
+  // Só formatamos o que reconhecemos como CPF. Qualquer outro valor é ocultado
+  // por completo para nunca devolver um dado que não soubemos interpretar.
+  if (digits.length !== 11) {
+    return FULLY_MASKED_CPF;
+  }
+
+  return `***.${digits.slice(3, 6)}.${digits.slice(6, 9)}-**`;
+}
+
+export function maskUserCpf<T extends { cpf: string }>(user: T): T {
+  return { ...user, cpf: maskCpf(user.cpf) };
+}
+
+export function maskUsersCpf<T extends { cpf: string }>(users: T[]): T[] {
+  return users.map((user) => maskUserCpf(user));
+}

--- a/back/src/students/students.controller.ts
+++ b/back/src/students/students.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get } from '@nestjs/common';
 import { StudentsService } from './students.service';
 import { Levels } from 'src/auth/decorators/levels.decorator';
 import { LEVELS } from 'src/constants';
+import { maskUsersCpf } from 'src/common/mask-cpf';
 
 @Controller('students')
 export class StudentsController {
@@ -9,7 +10,7 @@ export class StudentsController {
 
   @Levels(LEVELS.ALUNO_ESTUDANTE)
   @Get()
-  findAll() {
-    return this.studentsService.findAll();
+  async findAll() {
+    return maskUsersCpf(await this.studentsService.findAll());
   }
 }

--- a/back/src/users/users.controller.ts
+++ b/back/src/users/users.controller.ts
@@ -16,6 +16,7 @@ import { UpdateUserDto } from './dto/update-user.dto';
 import { ApiBody } from '@nestjs/swagger';
 import { Levels } from 'src/auth/decorators/levels.decorator';
 import { LEVELS } from 'src/constants';
+import { maskUserCpf, maskUsersCpf } from 'src/common/mask-cpf';
 
 @Controller('users')
 export class UsersController {
@@ -32,26 +33,27 @@ export class UsersController {
       'Objeto para criação de um novo usuário por um administrador.',
   })
   @Post()
-  create(@Body() createUserDto: CreateUserDto, @Req() req: Request) {
+  async create(@Body() createUserDto: CreateUserDto, @Req() req: Request) {
     const user = (req as Request & { user?: { id_level?: number } }).user;
 
     if (user?.id_level !== LEVELS.ADMIN) {
       throw new ForbiddenException('Apenas administradores podem cadastrar usuários');
     }
 
-    return this.usersService.create(createUserDto);
+    return maskUserCpf(await this.usersService.create(createUserDto));
   }
 
   @Levels(LEVELS.ALUNO_ESTUDANTE)
   @Get()
-  findAll() {
-    return this.usersService.findAll();
+  async findAll() {
+    return maskUsersCpf(await this.usersService.findAll());
   }
 
   @Levels(LEVELS.ALUNO_ESTUDANTE)
   @Get(':email')
-  findOne(@Param('email') email: string) {
-    return this.usersService.findOne(email);
+  async findOne(@Param('email') email: string) {
+    const user = await this.usersService.findOne(email);
+    return user ? maskUserCpf(user) : user;
   }
 
   @Levels(

--- a/back/test/common/mask-cpf.spec.ts
+++ b/back/test/common/mask-cpf.spec.ts
@@ -1,0 +1,70 @@
+import { maskCpf, maskUserCpf, maskUsersCpf } from 'src/common/mask-cpf';
+
+describe('maskCpf', () => {
+  it('should keep only the six middle digits of a valid cpf', () => {
+    expect(maskCpf('12345678910')).toBe('***.456.789-**');
+  });
+
+  it('should normalize a cpf that already comes formatted', () => {
+    expect(maskCpf('123.456.789-10')).toBe('***.456.789-**');
+  });
+
+  it('should fully mask an empty string', () => {
+    expect(maskCpf('')).toBe('***');
+  });
+
+  it('should fully mask a cpf with less than eleven digits', () => {
+    expect(maskCpf('1234567891')).toBe('***');
+  });
+
+  it('should fully mask a cpf with more than eleven digits', () => {
+    expect(maskCpf('123456789101')).toBe('***');
+  });
+
+  it('should fully mask a value without digits', () => {
+    expect(maskCpf('abcdefghijk')).toBe('***');
+  });
+
+  it('should fully mask a null or undefined value', () => {
+    expect(maskCpf(null as unknown as string)).toBe('***');
+    expect(maskCpf(undefined as unknown as string)).toBe('***');
+  });
+});
+
+describe('maskUserCpf', () => {
+  it('should mask the cpf without changing the other fields', () => {
+    const user = { id: 1, full_name: 'Test User', cpf: '12345678910' };
+
+    expect(maskUserCpf(user)).toEqual({
+      id: 1,
+      full_name: 'Test User',
+      cpf: '***.456.789-**',
+    });
+  });
+
+  it('should not mutate the original object', () => {
+    const user = { id: 1, cpf: '12345678910' };
+
+    maskUserCpf(user);
+
+    expect(user.cpf).toBe('12345678910');
+  });
+});
+
+describe('maskUsersCpf', () => {
+  it('should mask the cpf of every user in the list', () => {
+    const users = [
+      { id: 1, cpf: '12345678910' },
+      { id: 2, cpf: '98765432100' },
+    ];
+
+    expect(maskUsersCpf(users)).toEqual([
+      { id: 1, cpf: '***.456.789-**' },
+      { id: 2, cpf: '***.654.321-**' },
+    ]);
+  });
+
+  it('should return an empty list when there is no user', () => {
+    expect(maskUsersCpf([])).toEqual([]);
+  });
+});

--- a/back/test/students/students.controller.spec.ts
+++ b/back/test/students/students.controller.spec.ts
@@ -30,7 +30,7 @@ describe('PlansEducationController', () => {
   });
 
   describe('findAll', () => {
-    it('should return an array of students', async () => {
+    it('should return an array of students with masked cpf', async () => {
       const result = [
         {
           id: 1,
@@ -69,7 +69,12 @@ describe('PlansEducationController', () => {
       ];
       jest.spyOn(service, 'findAll').mockResolvedValue(result);
 
-      expect(await controller.findAll()).toEqual(result);
+      const masked = result.map((student) => ({
+        ...student,
+        cpf: '***.456.789-**',
+      }));
+
+      expect(await controller.findAll()).toEqual(masked);
       expect(service.findAll).toHaveBeenCalled();
     });
   });

--- a/back/test/users/users.controller.spec.ts
+++ b/back/test/users/users.controller.spec.ts
@@ -26,6 +26,8 @@ describe('UsersController', () => {
     deleted_at: null,
   };
 
+  const maskedUser = { ...mockUser, cpf: '***.456.789-**' };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
@@ -60,39 +62,47 @@ describe('UsersController', () => {
       const result = await controller.create(createDto as any, adminRequest);
 
       expect(service.create).toHaveBeenCalledWith(createDto);
-      expect(result).toEqual(mockUser);
+      expect(result).toEqual(maskedUser);
     });
 
-    it('should throw ForbiddenException when requester is not admin', () => {
+    it('should throw ForbiddenException when requester is not admin', async () => {
       const createDto = { full_name: 'New User', email: 'new@test.com', password: '123' };
       const nonAdminRequest = { user: { id_level: LEVELS.PROFISSIONAL_EDUCACAO } } as any;
 
-      expect(() => controller.create(createDto as any, nonAdminRequest)).toThrow(
-        ForbiddenException,
-      );
+      await expect(
+        controller.create(createDto as any, nonAdminRequest),
+      ).rejects.toThrow(ForbiddenException);
       expect(service.create).not.toHaveBeenCalled();
     });
   });
 
   describe('findAll', () => {
-    it('should return an array of users', async () => {
+    it('should return an array of users with masked cpf', async () => {
       jest.spyOn(service, 'findAll').mockResolvedValue([mockUser as any]);
 
       const result = await controller.findAll();
 
       expect(service.findAll).toHaveBeenCalled();
-      expect(result).toEqual([mockUser]);
+      expect(result).toEqual([maskedUser]);
     });
   });
 
   describe('findOne', () => {
-    it('should return a user by email', async () => {
+    it('should return a user by email with masked cpf', async () => {
       jest.spyOn(service, 'findOne').mockResolvedValue(mockUser);
 
       const result = await controller.findOne('test@test.com');
 
       expect(service.findOne).toHaveBeenCalledWith('test@test.com');
-      expect(result).toEqual(mockUser);
+      expect(result).toEqual(maskedUser);
+    });
+
+    it('should return null when the user does not exist', async () => {
+      jest.spyOn(service, 'findOne').mockResolvedValue(null);
+
+      const result = await controller.findOne('missing@test.com');
+
+      expect(result).toBeNull();
     });
   });
 


### PR DESCRIPTION
## 📌 Tipo de mudança

(Selecione apenas uma opçaõ)
tipo:

- [ ] marco-no-projeto
- [ ] nova-feature
- [x] bug-fix

## ✅ Checklist

checklist:

- [x] O código foi testado localmente
- [x] Foram adicionados testes relevantes
- [x] Não quebrou nenhuma funcionalidade existente
- [ ] A documentação foi atualizada

---

Closes #409

## O que muda

O CPF passa a sair da API mascarado no formato `***.456.789-**`, em vez de íntegro.

| Endpoint | Antes | Depois |
|---|---|---|
| `GET /users` | `12345678910` | `***.456.789-**` |
| `GET /users/:email` | `12345678910` | `***.456.789-**` |
| `POST /users` | `12345678910` | `***.456.789-**` |
| `GET /students` | `12345678910` | `***.456.789-**` |

## Por quê

O CPF é dado pessoal e estava totalmente exposto: a listagem de usuários o exibia cru para os níveis Administrador, Profissional da Educação e Profissional da Saúde, e ao abrir "Mais informações" o número ainda ia em **query string** (`front/src/components/TabelaEstudantes.tsx:36`), ficando registrado no histórico do navegador, em logs de proxy e na captura de sessão do Microsoft Clarity.

## Decisões de implementação

**A máscara é aplicada nos controllers, não nos services.** `UsersService.findOne` é consumido internamente por `AuthService.signIn`, `AuthService.updateProfile` e `AuthService.validateResetCode` — mascarar dentro do service quebraria login e recuperação de senha. O controller é a fronteira de saída da API e é onde a serialização pertence.

**O formato preserva os seis dígitos centrais.** O CPF cumpre hoje uma função puramente visual de desambiguar homônimos na listagem: não é usado no login (a chave de negócio é o e-mail), não aparece em nenhum `where` do backend e a busca da tela filtra apenas por `full_name`. Seis dígitos bastam para essa função.

**Valores inesperados são ocultados por completo.** Qualquer coisa que não seja 11 dígitos vira `***`, para nunca devolver um dado que a função não soube interpretar.

**O frontend não precisou de alteração.** O valor já chega mascarado, e como efeito colateral desejado o CPF propagado na query string de `/estudantes/visualizar` também passa a ser o mascarado — fechando aquele vazamento sem código adicional.

**O CPF continua armazenado íntegro no banco**; a `@unique` do campo segue garantindo que não haja duplicidade.

## Como testar

1. Autenticar como administrador e chamar `GET /users` — o campo `cpf` deve vir como `***.456.789-**`.
2. Abrir a listagem de usuários no front: coluna CPF (desktop) e card (mobile) exibem o valor mascarado.
3. Clicar em "Mais informações": a URL não deve mais conter o CPF completo.
4. Cadastrar um novo usuário: o fluxo continua funcionando normalmente e a resposta traz o CPF mascarado.
5. Buscar por nome na listagem: o filtro continua funcionando (ele nunca usou CPF).

## Testes

- Novo `back/test/common/mask-cpf.spec.ts` — CPF válido, CPF já formatado, string vazia, tamanho errado, valor sem dígitos, `null`/`undefined`, e a garantia de que o objeto original não é mutado.
- `back/test/users/users.controller.spec.ts` e `back/test/students/students.controller.spec.ts` ajustados para exigir o CPF mascarado na saída (os mocks continuam devolvendo o CPF cru, então o assert cobre de fato a máscara).
- Suíte completa do backend: **38 suites, 211 testes, todos passando**. Verificado também que 5 testes falham quando os controllers são revertidos, confirmando que a cobertura protege a correção.
- Front: `npm run lint` e `npm run build` sem erros.

