### PR TITLE
feat(front): integrar Microsoft Clarity com configuracao em runtime

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -33,3 +33,6 @@ MAIL_FROM=EduTrace <nao-responda@exemplo.com>
 API_URL=http://localhost:3001
 # Fallback legado usado apenas se API_URL nao estiver disponivel, recomendado deixar igual a API_URL
 NEXT_PUBLIC_API_EDU_TRACE=http://localhost:3001
+# ID do projeto no Microsoft Clarity (analytics). Se vazio, o front usa o ID padrao do codigo.
+# Fica "off" em desenvolvimento para que sessoes locais nao poluam os dados de producao.
+CLARITY_PROJECT_ID=off

--- a/.env.production.example
+++ b/.env.production.example
@@ -33,3 +33,6 @@ MAIL_FROM=EduTrace <nao-responda@exemplo.com>
 API_URL=url_da_api_producao
 # Fallback legado usado apenas se API_URL nao estiver disponivel (recomendado deixar igual a API_URL)
 NEXT_PUBLIC_API_EDU_TRACE=url_da_api_producao
+# ID do projeto no Microsoft Clarity (analytics). Se vazio, o front usa o ID padrao do codigo.
+# Use CLARITY_PROJECT_ID=off para desativar o Clarity neste ambiente.
+CLARITY_PROJECT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ k6_bin/
 k6-bin/
 *.zip
 k6/.env
+CLAUDE.md

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -55,6 +55,7 @@ services:
      - PORT=${PORT_MACHINE_FRONTEND}
      - API_URL=${API_URL}
      - NEXT_PUBLIC_API_EDU_TRACE=${NEXT_PUBLIC_API_EDU_TRACE}
+     - CLARITY_PROJECT_ID=${CLARITY_PROJECT_ID}
     networks:
       - app-net
     depends_on:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -8,6 +8,7 @@ services:
      - PORT=${PORT_MACHINE_FRONTEND}
      - API_URL=${API_URL}
      - NEXT_PUBLIC_API_EDU_TRACE=${NEXT_PUBLIC_API_EDU_TRACE}
+     - CLARITY_PROJECT_ID=${CLARITY_PROJECT_ID}
     networks:
      - app-net
     depends_on:

--- a/front/docker-entrypoint.sh
+++ b/front/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 cat > /app/public/runtime-config.js <<EOF
 window.__ENV__ = window.__ENV__ || {};
 window.__ENV__.API_URL = "${API_URL}";
+window.__ENV__.CLARITY_PROJECT_ID = "${CLARITY_PROJECT_ID}";
 EOF
 
 exec "$@"

--- a/front/public/runtime-config.js
+++ b/front/public/runtime-config.js
@@ -1,3 +1,5 @@
+// Placeholder usado apenas fora do Docker (next dev/start).
+// Em container, docker-entrypoint.sh sobrescreve este arquivo com os valores reais.
 window.__ENV__ = window.__ENV__ || {};
-window.__ENV__.API_URL = process.env.API_URL;
-
+window.__ENV__.API_URL = "";
+window.__ENV__.CLARITY_PROJECT_ID = "off";

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
 import { ClientProviders } from "./ClientProviders";
+import { MicrosoftClarity } from "@/components/MicrosoftClarity";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -31,10 +32,12 @@ export default function RootLayout({
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        data-clarity-mask="true"
       >
         <ClientProviders>
           {children}
         </ClientProviders>
+        <MicrosoftClarity />
       </body>
     </html>
   );

--- a/front/src/components/MicrosoftClarity.tsx
+++ b/front/src/components/MicrosoftClarity.tsx
@@ -1,0 +1,17 @@
+import Script from "next/script";
+
+const DEFAULT_CLARITY_PROJECT_ID = "x7y5hk661u";
+
+export function MicrosoftClarity() {
+  return (
+    <Script id="microsoft-clarity" strategy="afterInteractive">
+      {`(function(c,l,a,r,i,t,y){
+        i=(c.__ENV__&&c.__ENV__.CLARITY_PROJECT_ID)||"${DEFAULT_CLARITY_PROJECT_ID}";
+        if(!i||i==="off"){return;}
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script");`}
+    </Script>
+  );
+}

--- a/front/src/utils/runtimeApiUrl.ts
+++ b/front/src/utils/runtimeApiUrl.ts
@@ -2,6 +2,7 @@ declare global {
   interface Window {
     __ENV__?: {
       API_URL?: string;
+      CLARITY_PROJECT_ID?: string;
     };
   }
 }

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 📌 Tipo de mudança

<!-- Selecione UMA das opções abaixo -->

(Selecione apenas uma opçaõ)
tipo:

- [ ] marco-no-projeto
- [x] nova-feature
- [ ] bug-fix

## ✅ Checklist

<!-- Marque com um "x" os itens que se aplicam -->

checklist:

- [x] O código foi testado localmente
- [ ] Foram adicionados testes relevantes
- [x] Não quebrou nenhuma funcionalidade existente
- [x] A documentação foi atualizada

---

## O que muda

Integra o Microsoft Clarity (analytics / session replay) ao frontend.

O project ID é resolvido **em runtime** via `window.__ENV__`, seguindo o padrão que o projeto já usa em `front/src/utils/runtimeApiUrl.ts` — e deliberadamente **não** via `NEXT_PUBLIC_*`.

### Por que não NEXT_PUBLIC_

Variáveis `NEXT_PUBLIC_*` são embutidas em **build time**. O `front/Dockerfile` não declara nenhum `ARG`, então o valor chegaria vazio na imagem e o Clarity ficaria **desligado em produção sem erro visível**. (O mesmo já acontece hoje com o `--build-arg NEXT_PUBLIC_API_EDU_TRACE` do `frontend-pipeline.yml` — ele é ignorado silenciosamente; foi por isso que o `runtime-config.js` existe. **Este PR não mexe na pipeline.**)

### Comportamento de `CLARITY_PROJECT_ID`

| Valor | Resultado |
|---|---|
| não definida / vazia | usa o ID padrão do código (produção continua funcionando sem config) |
| um project ID | usa esse ID |
| `off` | Clarity desativado |

Fora do Docker (`next dev`), o placeholder `public/runtime-config.js` define `off`, para que **sessões locais não poluam os dados de produção**.

### Privacidade (LGPD)

O app exibe CPF, nome e e-mail de estudantes. Foi aplicado `data-clarity-mask="true"` no `<body>`, mascarando o texto nas gravações.

> ⚠️ **Ação necessária fora do repo:** ativar *Settings → Masking → Mask all text* no dashboard do Clarity. O atributo no código não substitui esse controle.

### Correção incidental

`public/runtime-config.js` lançava `ReferenceError: process is not defined` no browser (`process.env` não existe no client). Corrigido. `API_URL` vazia é falsy e mantém o mesmo fallback para `NEXT_PUBLIC_API_EDU_TRACE` em `getApiUrl()` — comportamento inalterado.

## Verificação

- `npx tsc --noEmit` sem erros; `npm run build` gera `.next/standalone/server.js`
- `docker-entrypoint.sh` testado nos 3 casos (var ausente / com ID / `off`) — gera o `runtime-config.js` esperado
- Lógica do snippet validada nos 5 cenários de resolução do ID
- No browser: `clarity.js` carrega e inicializa (`typeof window.clarity === "function"`), `data-clarity-mask="true"` presente no `<body>`, e com `off` o script **não** carrega. Zero erros no console
- **Rede de produção:** não há CSP em lugar nenhum (`next.config.ts` sem `headers()`, sem `helmet` no back, sem nginx/traefik versionado). O Nginx Proxy Manager não injeta CSP por padrão — o Clarity não será barrado

## Nota de deploy

Adicionar `CLARITY_PROJECT_ID` na stack do Portainer é **opcional** — há fallback. Só é necessário para trocar o projeto ou desativar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
