### PR TITLE
build(front): adicionar .dockerignore para reduzir contexto de build

### DIFF
--- a/front/.dockerignore
+++ b/front/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.git
+dist
+Dockerfile
+.dockerignore
+npm-debug.log*
+.env*.local


### PR DESCRIPTION
Sem .dockerignore, o contexto de build enviado ao daemon incluia a pasta inteira do front, com node_modules (598 MB) e .next (190 MB) - ~701 MB no total. A transferencia levava ~18 min e derrubava a conexao com o daemon (failed to solve: Unavailable ... unexpected EOF), quebrando o build da imagem next-app.

Esses diretorios sao inuteis no contexto: o Dockerfile recria node_modules via npm ci e .next via npm run build dentro do container. Ignorando-os (alem de .git, dist, Dockerfile e arquivos de log/env locais), o contexto cai de ~701 MB para ~1,7 MB.

## 📌 Tipo de mudançaAdd commentMore actions

<!-- Selecione UMA das opções abaixo -->

(Selecione apenas uma opçaõ)
tipo:

- [ ] marco-no-projeto
- [ ] nova-feature
- [x] bug-fix

## ✅ Checklist

<!-- Marque com um "x" os itens que se aplicam -->

checklist:

- [x] O código foi testado localmente
- [ ] Foram adicionados testes relevantes
- [x] Não quebrou nenhuma funcionalidade existente
- [ ] A documentação foi atualizada

---

> _Preencha todos os campos de forma clara. Este template é lido automaticamente por nossa pipeline._
